### PR TITLE
Add getter method for configuration in FlexMotor and SparkMaxMotor

### DIFF
--- a/src/main/java/frc/excalib/control/motor/controllers/FlexMotor.java
+++ b/src/main/java/frc/excalib/control/motor/controllers/FlexMotor.java
@@ -128,4 +128,6 @@ public class FlexMotor extends SparkFlex implements Motor {
     private void configure() {
         super.configure(m_config, kResetSafeParameters, kPersistParameters);
     }
+
+    public SparkFlexConfig getConfig(){ return m_config; }
 }

--- a/src/main/java/frc/excalib/control/motor/controllers/SparkMaxMotor.java
+++ b/src/main/java/frc/excalib/control/motor/controllers/SparkMaxMotor.java
@@ -129,4 +129,6 @@ public class SparkMaxMotor extends SparkMax implements Motor {
     private void configure() {
         super.configure(m_config, kResetSafeParameters, kPersistParameters);
     }
+
+    public SparkFlexConfig getConfig(){ return m_config;}
 }


### PR DESCRIPTION
This pull request introduces a small enhancement to the motor controller classes by adding a new `getConfig` method in both `FlexMotor` and `SparkMaxMotor`. This method allows external access to the motor configuration object (`m_config`).

Changes by file:

* [`src/main/java/frc/excalib/control/motor/controllers/FlexMotor.java`](diffhunk://#diff-bd44b461514f4d9381a38d2eae062eaccbfe0d7162e8f0b35f4c6ba239fc3205R131-R132): Added `public SparkFlexConfig getConfig()` method to return the motor configuration.
* [`src/main/java/frc/excalib/control/motor/controllers/SparkMaxMotor.java`](diffhunk://#diff-464290804a26d55616cdbb0a4195efd9a91d597316ffbfa70b3c589f43de6806R132-R133): Added `public SparkFlexConfig getConfig()` method to return the motor configuration.